### PR TITLE
Allow the use of the mode paramenter in the core render function

### DIFF
--- a/plangym/core.py
+++ b/plangym/core.py
@@ -343,6 +343,6 @@ class GymEnvironment(BaseEnvironment):
         else:
             return new_states, observs, rewards, terminals, infos
 
-    def render(self, mode='human'):
+    def render(self, mode="human"):
         """Render the environment using OpenGL. This wraps the OpenAI render method."""
         return self.gym_env.render(mode)


### PR DESCRIPTION
I was trying to get the image as a NumPy array and I see that It was added the parameter to the render method.
With the value human, it will keep the default action that displays the gym viewer, but if you add the mode numpy_array, it will keep the original functionality that is return an image as a NumPy array.